### PR TITLE
feat(ios): save via ASCredentialDataManager on iOS 26.2+, with optional title

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ On iOS 26.2 and later, `promptDialog` saves through [`ASCredentialDataManager`](
 
 Either way the `url` option names the domain the credential is saved against, and it must be one of the `webcredentials:` associated domains you set up above.
 
+Note the two paths differ in what they report back. `SecAddSharedWebCredential` surfaces a dismissed prompt as an error, so `promptDialog` rejects. `ASCredentialDataManager` only throws when the system rejects the update — Apple describe it as equivalent to submitting a password form, so the user's choice never reaches the app. On 26.2 and later, treat a resolved promise as "the system accepted the request", not as confirmation that the password was saved.
+
 On 26.2 and later you can also pass `title` to control the name the credential is filed under. Without it the password manager falls back to the bare domain, so users see `app.example.com` rather than your product name. The old API has no equivalent, so `title` is ignored below 26.2.
 
 ## API
@@ -131,6 +133,12 @@ promptDialog(options: Options) => Promise<void>
 ```
 
 Save a password to the keychain.
+
+On iOS 26.2 and later, resolving means the system accepted the request —
+not that the credential was stored. The save prompt belongs to the system
+and the user's choice is not reported back, so do not treat a resolved
+promise as confirmation. Below 26.2, and on Android, dismissing the prompt
+rejects.
 
 | Param         | Type                                        | Description                     |
 | ------------- | ------------------------------------------- | ------------------------------- |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Prompt to display dialog for saving password to keychain from webview app
   <h2><a href="https://capgo.app/consulting/?ref=plugin_autofill_save_password"> Missing a feature? We’ll build the plugin for you 💪</a></h2>
 </div>
 
-Fork of original plugin to work with Capacitor 7 
-
-IOS work for old versions and 18.3
+Fork of original plugin to work with Capacitor 7+
 
 ## Documentation
 
@@ -63,10 +61,6 @@ Then add in your `App.entitlements`
 
 To associate your domain to your app.
 
-### iOS 26.2 and later
-
-`promptDialog` saves through [`ASCredentialDataManager`](https://developer.apple.com/documentation/authenticationservices/ascredentialdatamanager), which routes the save to whichever credential provider the user has chosen — iCloud Keychain or a third-party manager. Below 26.2 it falls back to `SecAddSharedWebCredential`, which Apple deprecated in 26.2 and which only ever writes to iCloud Keychain. Either way the `url` option names the domain the credential is saved against, and it must be one of your `webcredentials:` associated domains.
-
 ## How to use
 ```ts
 import { Capacitor } from '@capacitor/core';
@@ -107,6 +101,12 @@ with
     }]
     </string>
 ```
+
+### iOS
+
+On iOS 26.2 and later, `promptDialog` saves through [`ASCredentialDataManager`](https://developer.apple.com/documentation/authenticationservices/ascredentialdatamanager), which routes the save to whichever credential provider the user has chosen — iCloud Keychain or a third-party manager. Below 26.2 it falls back to `SecAddSharedWebCredential`, which Apple deprecated in 26.2 and which only ever writes to iCloud Keychain.
+
+Either way the `url` option names the domain the credential is saved against, and it must be one of the `webcredentials:` associated domains you set up above.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ On iOS 26.2 and later, `promptDialog` saves through [`ASCredentialDataManager`](
 
 Either way the `url` option names the domain the credential is saved against, and it must be one of the `webcredentials:` associated domains you set up above.
 
+On 26.2 and later you can also pass `title` to control the name the credential is filed under. Without it the password manager falls back to the bare domain, so users see `app.example.com` rather than your product name. The old API has no equivalent, so `title` is ignored below 26.2.
+
 ## API
 
 <docgen-index>
@@ -170,11 +172,12 @@ Get the native Capacitor plugin version.
 
 #### Options
 
-| Prop           | Type                | Description                                                                    |
-| -------------- | ------------------- | ------------------------------------------------------------------------------ |
-| **`username`** | <code>string</code> | The username to save.                                                          |
-| **`password`** | <code>string</code> | The password to save.                                                          |
-| **`url`**      | <code>string</code> | The url to save the password for. (For example: "console.capgo.app") iOS only. |
+| Prop           | Type                | Description                                                                                                                                         |
+| -------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`username`** | <code>string</code> | The username to save.                                                                                                                               |
+| **`password`** | <code>string</code> | The password to save.                                                                                                                               |
+| **`url`**      | <code>string</code> | The url to save the password for. (For example: "console.capgo.app") iOS only.                                                                      |
+| **`title`**    | <code>string</code> | The name the credential is filed under in the password manager. (For example: "Capgo"). Defaults to the domain from `url`. iOS 26.2 and later only. |
 
 
 #### ReadPasswordResult

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Then add in your `App.entitlements`
 
 To associate your domain to your app.
 
+### iOS 26.2 and later
+
+`promptDialog` saves through [`ASCredentialDataManager`](https://developer.apple.com/documentation/authenticationservices/ascredentialdatamanager), which routes the save to whichever credential provider the user has chosen — iCloud Keychain or a third-party manager. Below 26.2 it falls back to `SecAddSharedWebCredential`, which Apple deprecated in 26.2 and which only ever writes to iCloud Keychain. Either way the `url` option names the domain the credential is saved against, and it must be one of your `webcredentials:` associated domains.
+
 ## How to use
 ```ts
 import { Capacitor } from '@capacitor/core';

--- a/ios/Sources/SavePasswordPlugin/SavePasswordPlugin.swift
+++ b/ios/Sources/SavePasswordPlugin/SavePasswordPlugin.swift
@@ -31,7 +31,13 @@ public class SavePasswordPlugin: CAPPlugin, CAPBridgedPlugin, ASAuthorizationCon
         }
 
         if #available(iOS 26.2, *) {
-            saveWithCredentialDataManager(call, username: username, password: password, url: url)
+            saveWithCredentialDataManager(
+                call,
+                username: username,
+                password: password,
+                url: url,
+                title: call.getString("title")
+            )
             return
         }
 
@@ -39,7 +45,9 @@ public class SavePasswordPlugin: CAPPlugin, CAPBridgedPlugin, ASAuthorizationCon
     }
 
     @available(iOS 26.2, *)
-    private func saveWithCredentialDataManager(_ call: CAPPluginCall, username: String, password: String, url: String) {
+    private func saveWithCredentialDataManager(
+        _ call: CAPPluginCall, username: String, password: String, url: String, title: String?
+    ) {
         Task { @MainActor in
             guard let anchor = self.bridge?.viewController?.view.window else {
                 call.reject("Failed to save credential", "No window to present the save prompt from")
@@ -49,6 +57,7 @@ public class SavePasswordPlugin: CAPPlugin, CAPBridgedPlugin, ASAuthorizationCon
                 try await ASCredentialDataManager().save(
                     password: ASPasswordCredential(user: username, password: password),
                     for: Self.autoFillScope(for: url),
+                    title: title,
                     anchor: anchor
                 )
                 call.resolve()

--- a/ios/Sources/SavePasswordPlugin/SavePasswordPlugin.swift
+++ b/ios/Sources/SavePasswordPlugin/SavePasswordPlugin.swift
@@ -29,6 +29,48 @@ public class SavePasswordPlugin: CAPPlugin, CAPBridgedPlugin, ASAuthorizationCon
             call.reject("URL is required for iOS shared web credentials")
             return
         }
+
+        if #available(iOS 26.2, *) {
+            saveWithCredentialDataManager(call, username: username, password: password, url: url)
+            return
+        }
+
+        saveWithSharedWebCredential(call, username: username, password: password, url: url)
+    }
+
+    @available(iOS 26.2, *)
+    private func saveWithCredentialDataManager(_ call: CAPPluginCall, username: String, password: String, url: String) {
+        Task { @MainActor in
+            guard let anchor = self.bridge?.viewController?.view.window else {
+                call.reject("Failed to save credential", "No window to present the save prompt from")
+                return
+            }
+            do {
+                try await ASCredentialDataManager().save(
+                    password: ASPasswordCredential(user: username, password: password),
+                    for: Self.autoFillScope(for: url),
+                    anchor: anchor
+                )
+                call.resolve()
+            } catch {
+                call.reject("Failed to save credential", error.localizedDescription)
+            }
+        }
+    }
+
+    @available(iOS 26.2, *)
+    private static func autoFillScope(for url: String) -> ASAutoFillURLScope {
+        // `url` is documented as a bare FQDN, but tolerate a full URL rather than
+        // handing "https://example.com" to the host initialiser verbatim
+        guard let parsed = URL(string: url), parsed.scheme != nil,
+              let scope = ASAutoFillURLScope(url: parsed) else {
+            return ASAutoFillURLScope(host: url)
+        }
+        return scope
+    }
+
+    @available(iOS, deprecated: 26.2, message: "Superseded by ASCredentialDataManager")
+    private func saveWithSharedWebCredential(_ call: CAPPluginCall, username: String, password: String, url: String) {
         let fqdn = url as CFString
         let user = username as CFString
         let pass = password as CFString

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -42,8 +42,15 @@ export interface ReadPasswordResult {
 export interface SavePasswordPlugin {
   /**
    * Save a password to the keychain.
+   *
+   * On iOS 26.2 and later, resolving means the system accepted the request —
+   * not that the credential was stored. The save prompt belongs to the system
+   * and the user's choice is not reported back, so do not treat a resolved
+   * promise as confirmation. Below 26.2, and on Android, dismissing the prompt
+   * rejects.
+   *
    * @param {Options} options - The options for the password.
-   * @returns {Promise<void>} Success status
+   * @returns {Promise<void>}
    * @example
    * await SavePassword.promptDialog({
    *   username: 'your-username',

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -16,6 +16,12 @@ export interface Options {
    * iOS only.
    */
   url?: string;
+  /**
+   * The name the credential is filed under in the password manager.
+   * (For example: "Capgo"). Defaults to the domain from `url`.
+   * iOS 26.2 and later only.
+   */
+  title?: string;
 }
 
 export interface ReadPasswordResult {


### PR DESCRIPTION
## What
- `promptDialog` saves through `ASCredentialDataManager.save(password:for:title:anchor:)` on iOS 26.2+, falling back to `SecAddSharedWebCredential` below that.
- Adds an optional `title` option so the saved credential can be filed under a product name.
- README: the iOS notes now sit alongside the existing Android section, and the stale "IOS work for old versions and 18.3" line is gone.

## Why
The iOS 26.5 SDK deprecates `SecAddSharedWebCredential` as of 26.2, naming the replacement directly:

```
API_DEPRECATED("Use ASCredentialDataManager.save(password:for:title:anchor:)  (AuthenticationServices framework)",
               ios(8.0, 26.2), macCatalyst(14.0, 26.2), macos(11.0, 26.2))
```

Beyond staying ahead of the removal, it is a behaviour win. The old call only ever writes to iCloud Keychain; the 26.2 provider APIs let the user's chosen credential manager handle the save. On a test device with 1Password set as the provider, the credential went to 1Password — which for a webview app is the difference between third-party password manager users getting a save prompt and getting nothing.

The `title` came out of the same testing: without one, managers fall back to the bare domain, so a saved entry reads `app.example.com` instead of the product name.

## How
- `promptDialog` keeps its existing argument validation and branches on `#available(iOS 26.2, *)`.
- The new path builds an `ASPasswordCredential` and an `ASAutoFillURLScope` from the existing `url` option, and presents from the bridge's window on `@MainActor`. `url` is documented as a bare FQDN, so the scope helper only goes through `ASAutoFillURLScope(url:)` when the string carries an explicit scheme, otherwise `ASAutoFillURLScope(host:)`.
- The legacy path moved into its own method marked `@available(iOS, deprecated: 26.2, ...)`, which keeps the build free of deprecation warnings without a blanket suppression.
- `title` is optional and additive, so `definitions.ts` stays backward compatible — no migration, and nothing changes for callers that omit it. It is ignored below 26.2, since `SecAddSharedWebCredential` has no equivalent.

## Testing
- **On device.** Physical iPhone 17 Pro Max running iOS 27.0, in a production Capacitor app with associated domains configured, the `webcredentials:` entitlement present and a matching AASA served. Creating an account raises the system save prompt and the credential saves into 1Password. Confirmed before installing that the built framework links `ASCredentialDataManager`, so this exercised the new path rather than the fallback. Re-tested after adding `title` and the entry is named accordingly.
- `bun run verify:ios` — builds clean against the iOS 26.5 SDK (Xcode 26.6), no warnings.
- `bun run lint` — eslint and prettier pass.
- `bun run build` — docgen re-run, so the README API table includes `title`.

## Not Tested
- **The `SecAddSharedWebCredential` fallback.** The test device is on 27.0, so it always takes the 26.2+ branch. The legacy path is byte-for-byte the previous implementation, just relocated behind an availability check, but it has not been re-run on a device below 26.2.
- SwiftLint did not run locally (not on PATH) — leaving that to CI. All added lines are under 120 chars.
- Android and web are untouched, so `verify:android` / `verify:web` were not run.
- Not built with Xcode 27 beta. Unrelated to this change — a third-party pod in the host app fails to compile under that toolchain — but it means this has only been built with the 26.5 SDK.

## Disclosure
Written by Claude Code (Claude Opus 5), reviewed and device-tested by me before opening. Flagging per your AGENTS.md note on AI-generated PRs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-autofill-save-password/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional iOS 26.2+ title for naming saved credentials.
  * Updated password-saving behavior for iOS 26.2 and later, including customizable dialog titles.
  * Added support for credential saving from full URLs or hostnames.

* **Documentation**
  * Updated documentation for Capacitor 7+ compatibility and iOS-specific `promptDialog` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->